### PR TITLE
Made compatible with new s-expr format for annotations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -663,6 +663,7 @@ name = "pancake2viper"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "lazy_static",
  "pest",
  "pest_derive",
  "sexpr_parser",

--- a/pancake2viper/src/annotation/annot.pest
+++ b/pancake2viper/src/annotation/annot.pest
@@ -53,4 +53,4 @@ top_keywords = _{ pre | post | invariant | assertion | inhale | exhale }
     inhale = { "inhale" }
     exhale = { "exhale" }
 
-top = {top_keywords ~ expr }
+top = {"@"? ~ WHITESPACE* ~ top_keywords ~ expr ~ WHITESPACE* ~ "@"? }

--- a/pancake2viper/src/pancake/statement.rs
+++ b/pancake2viper/src/pancake/statement.rs
@@ -163,9 +163,10 @@ pub fn parse_stmt_symbol(symbol: &str) -> anyhow::Result<Stmt> {
 
 pub fn parse_stmt(s: Vec<&SExpr>) -> anyhow::Result<Stmt> {
     match &s[..] {
-        [Symbol(op), Symbol(at1), rem @ .., Symbol(at2)] if op == "annot" && at1 == at2 => {
-            let sl = rem.iter().map(|&s| sexpr_to_str(s)).collect::<Vec<_>>();
-            Ok(Stmt::Annotation(Annotation { line: sl.join(" ") }))
+        [Symbol(op), SString(at), SString(annot)] if op == "annot" && at == "@" => {
+            Ok(Stmt::Annotation(Annotation {
+                line: annot.to_owned(),
+            }))
         }
         [Symbol(op)] => parse_stmt_symbol(op),
         // Variable declaration
@@ -364,19 +365,4 @@ fn parse_seq(s: &[&SExpr]) -> anyhow::Result<Stmt> {
         }
     }
     Ok(Stmt::Seq(Seq { stmts }))
-}
-
-// fn try_parse_annot
-
-fn sexpr_to_str(sexpr: &SExpr) -> String {
-    match sexpr {
-        SExpr::Int(i) => i.to_string(),
-        SExpr::SString(s) => s.to_owned(),
-        SExpr::Symbol(s) => s.to_owned(),
-        SExpr::List(l) => {
-            let sl: Vec<_> = l.iter().map(sexpr_to_str).collect();
-            format!("({})", sl.join(" "))
-        }
-        _ => todo!(),
-    }
 }


### PR DESCRIPTION
now runs with cake version: 
```
Wed Sep 25 20:35:51 2024 UTC

CakeML: 49f0d44be26ff907ef52240f3818a4c3caa10598
HOL4:   72a01e7935ee7175f22527332d54ac58085668ed
PolyML: Poly/ML 5.9 Release    RTS version: X86_64-5.
```