### PR TITLE
Automatic argument precondition for non-`1` shapes

### DIFF
--- a/pancake2viper/src/ir/statement.rs
+++ b/pancake2viper/src/ir/statement.rs
@@ -18,7 +18,6 @@ pub enum Stmt {
     Break,
     Continue,
     Call(Call),
-    TailCall(TailCall),
     ExtCall(ExtCall),
     Return(Return),
 }
@@ -105,15 +104,7 @@ pub struct While {
 
 #[derive(Debug, Clone)]
 pub struct Call {
-    pub rettype: String,
-    pub fname: Expr,
-    pub args: Vec<Expr>,
-}
-
-#[derive(Debug, Clone)]
-pub struct TailCall {
-    pub fname: Expr,
-    pub args: Vec<Expr>,
+    pub call: Expr,
 }
 
 #[derive(Debug, Clone)]

--- a/pancake2viper/src/ir_to_viper/expression.rs
+++ b/pancake2viper/src/ir_to_viper/expression.rs
@@ -405,3 +405,10 @@ impl<'a> ToViper<'a> for Vec<ir::Expr> {
             .collect::<Vec<_>>()
     }
 }
+
+impl<'a, const T: usize> ToViper<'a> for [ir::Expr; T] {
+    type Output = [viper::Expr<'a>; T];
+    fn to_viper(self, ctx: &mut ViperEncodeCtx<'a>) -> Self::Output {
+        self.map(|e| e.to_viper(ctx))
+    }
+}

--- a/pancake2viper/src/ir_to_viper/expression.rs
+++ b/pancake2viper/src/ir_to_viper/expression.rs
@@ -285,6 +285,44 @@ impl<'a> ToViper<'a> for ir::FunctionCall {
     }
 }
 
+impl<'a> ToViper<'a> for ir::MethodCall {
+    type Output = viper::Expr<'a>;
+    fn to_viper(self, ctx: &mut ViperEncodeCtx<'a>) -> Self::Output {
+        let ast = ctx.ast;
+        let ret = ast.new_var(&ctx.fresh_var(), self.rettype.to_viper_type(ctx));
+        let method_name = ctx.mangler.mangle_fn(&self.fname.label_to_viper());
+
+        let mut args = vec![];
+
+        for arg in self.args {
+            let arg = match arg.shape(ctx) {
+                Shape::Simple => arg.to_viper(ctx),
+                Shape::Nested(_) => {
+                    let fresh = ast.new_var(&ctx.fresh_var(), arg.shape(ctx).to_viper_type(ctx));
+                    let arg_len = arg.shape(ctx).len();
+                    let viper_arg = arg.to_viper(ctx);
+                    let copy_arg = ctx.iarray.create_slice_m(
+                        viper_arg,
+                        ast.int_lit(0),
+                        ast.int_lit(arg_len as i64),
+                        fresh.1,
+                    );
+                    ctx.declarations.push(fresh.0);
+                    ctx.stack.push(copy_arg);
+                    fresh.1
+                }
+            };
+            args.push(arg);
+        }
+        args.insert(0, ctx.heap_var().1);
+
+        let call = ast.method_call(&method_name, &args, &[ret.1]);
+        ctx.declarations.push(ret.0);
+        ctx.stack.push(call);
+        ret.1
+    }
+}
+
 impl<'a> ToViper<'a> for ir::HeapAccess {
     type Output = viper::Expr<'a>;
     fn to_viper(self, ctx: &mut ViperEncodeCtx<'a>) -> Self::Output {
@@ -362,7 +400,7 @@ impl<'a> ToViper<'a> for ir::Expr {
             UnOp(op) => op.to_viper(ctx),
             BinOp(op) => op.to_viper(ctx),
             FunctionCall(call) => call.to_viper(ctx),
-            MethodCall(_) => panic!("Should only be possible as part of a DecCall"),
+            MethodCall(call) => call.to_viper(ctx),
             Shift(shift) => shift.to_viper(ctx),
             Load(load) => load.to_viper(ctx),
             LoadByte(load) => load.to_viper(ctx),

--- a/pancake2viper/src/ir_to_viper/statement.rs
+++ b/pancake2viper/src/ir_to_viper/statement.rs
@@ -210,11 +210,7 @@ impl<'a> ToViper<'a> for ir::ExtCall {
     type Output = viper::Stmt<'a>;
     fn to_viper(self, ctx: &mut ViperEncodeCtx<'a>) -> Self::Output {
         let ast = ctx.ast;
-        let args = self
-            .args
-            .into_iter()
-            .map(|a| a.to_viper(ctx))
-            .collect::<Vec<_>>();
+        let args = self.args.to_viper(ctx);
         ast.method_call(&format!("ffi_{}", self.fname), &args, &[])
     }
 }
@@ -223,11 +219,7 @@ impl<'a> ToViper<'a> for ir::TailCall {
     type Output = viper::Stmt<'a>;
     fn to_viper(self, ctx: &mut ViperEncodeCtx<'a>) -> Self::Output {
         let ast = ctx.ast;
-        let mut args = self
-            .args
-            .into_iter()
-            .map(|a| a.to_viper(ctx))
-            .collect::<Vec<_>>();
+        let mut args = self.args.to_viper(ctx);
         args.insert(0, ctx.heap_var().1);
         let ret = ctx.return_var();
         let call = ast.method_call(

--- a/pancake2viper/src/ir_to_viper/toplevel.rs
+++ b/pancake2viper/src/ir_to_viper/toplevel.rs
@@ -57,11 +57,18 @@ impl<'a> ToViper<'a> for FnDec {
         args_assigns.extend_from_slice(&[body, ast.label(ctx.return_label(), &[])]);
         let body = ast.seqn(&args_assigns, &args_decls);
 
+        let mut pres = self
+            .args
+            .iter()
+            .filter_map(|a| a.permission(ctx))
+            .collect::<Vec<_>>();
+        pres.extend(&ctx.pres);
+
         ast.method(
             &ctx.mangler.mangle_fn(&self.fname),
             &args_local_decls,
             &[ctx.return_var().0],
-            &ctx.pres,
+            &pres,
             &ctx.posts,
             Some(body),
         )

--- a/pancake2viper/src/ir_to_viper/utils/auto.rs
+++ b/pancake2viper/src/ir_to_viper/utils/auto.rs
@@ -1,0 +1,34 @@
+use viper::Expr;
+
+use crate::{ir::Arg, shape::Shape, utils::ViperUtils, ToViperType};
+
+use super::{Mangler, ViperEncodeCtx};
+
+impl Arg {
+    /// Generates preconditions for an argument
+    ///
+    /// If an `Arg` is not of shape `1` it is encoded as an `IArray`.
+    /// Therefore it needs both access permissions to the slots and its length
+    /// as a precondition in the method.
+    pub fn permission<'a>(&self, ctx: &ViperEncodeCtx<'a>) -> Option<Expr<'a>> {
+        let ast = ctx.ast;
+        match self.shape {
+            Shape::Simple => None,
+            Shape::Nested(_) => {
+                let arg_var = ctx
+                    .ast
+                    .new_var(
+                        &Mangler::mangle_arg(&self.name),
+                        self.shape.to_viper_type(ctx),
+                    )
+                    .1;
+                let length = ast.int_lit(self.shape.len() as i64);
+                let access_perm =
+                    ctx.iarray
+                        .array_acc_expr(arg_var, ast.int_lit(0), length, ast.full_perm());
+                let length_pre = ast.eq_cmp(ctx.iarray.len_f(arg_var), length);
+                Some(ast.and(length_pre, access_perm))
+            }
+        }
+    }
+}

--- a/pancake2viper/src/ir_to_viper/utils/mod.rs
+++ b/pancake2viper/src/ir_to_viper/utils/mod.rs
@@ -1,3 +1,4 @@
+mod auto;
 mod context;
 mod mangler;
 

--- a/pancake2viper/src/pancake_to_ir/statement.rs
+++ b/pancake2viper/src/pancake_to_ir/statement.rs
@@ -125,20 +125,24 @@ impl From<pancake::Call> for ir::Call {
     fn from(value: pancake::Call) -> Self {
         let args: Wrapper<ir::Expr> = value.args.into();
         Self {
-            rettype: value.rettype,
-            fname: value.fname.into(),
-            args: args.0,
+            call: ir::Expr::MethodCall(ir::MethodCall {
+                fname: Box::new(value.fname.into()),
+                rettype: crate::shape::Shape::Simple, // FIXME
+                args: args.0,
+            }),
         }
     }
 }
 
-// XXX: do we want this in our IR? -> call + return
-impl From<pancake::TailCall> for ir::TailCall {
+impl From<pancake::TailCall> for ir::Return {
     fn from(value: pancake::TailCall) -> Self {
         let args: Wrapper<ir::Expr> = value.args.into();
-        Self {
-            fname: value.fname.into(),
-            args: args.0,
+        ir::Return {
+            value: ir::Expr::MethodCall(ir::MethodCall {
+                fname: Box::new(value.fname.into()),
+                args: args.0,
+                rettype: crate::shape::Shape::Simple, // FIXME
+            }),
         }
     }
 }
@@ -181,7 +185,7 @@ impl From<pancake::Stmt> for ir::Stmt {
             Break => Self::Break,
             Continue => Self::Continue,
             Call(c) => Self::Call(c.into()),
-            TailCall(t) => Self::TailCall(t.into()),
+            TailCall(t) => Self::Return(t.into()),
             ExtCall(e) => Self::ExtCall(e.into()),
             Raise(_) | Tick => panic!("Raise and Tick are not implemented"),
             Return(r) => Self::Return(r.into()),

--- a/pancake2viper/tests/arg_copy_semantics.pnk
+++ b/pancake2viper/tests/arg_copy_semantics.pnk
@@ -1,0 +1,10 @@
+fun main(2 x) {
+    /*@ requires x.0 == 42 @*/
+    do_stuff(x);
+    return x.0;
+}
+
+fun do_stuff(2 x) {
+    x = < 0, 0 >;
+    return 0;
+}

--- a/pancake2viper/tests/arg_copy_semantics.pnk
+++ b/pancake2viper/tests/arg_copy_semantics.pnk
@@ -1,5 +1,6 @@
 fun main(2 x) {
     /*@ requires x.0 == 42 @*/
+    /*@ ensures retval == 42 @*/
     do_stuff(x);
     return x.0;
 }

--- a/pancake2viper/tests/auto_arg.pnk
+++ b/pancake2viper/tests/auto_arg.pnk
@@ -1,0 +1,3 @@
+fun main(2 x) {
+    return x.0;
+}


### PR DESCRIPTION
- fix #6: Automatic argument precondition for non-`1` shapes
- fixed method calls not using copy semantics on non-`1` shapes