### PR TITLE
Feature/predicates

### DIFF
--- a/pancake2viper/src/annotation/annot.pest
+++ b/pancake2viper/src/annotation/annot.pest
@@ -60,13 +60,15 @@ expr = !{ prefix? ~ primary ~ postfix? ~ (infix ~ prefix? ~ primary ~ postfix?)*
 
 
 annotation = {"@"? ~ WHITESPACE* ~ annotation_keyword ~ expr ~ WHITESPACE* ~ "@"? }
-    annotation_keyword = _{ pre | post | invariant | assertion | inhale | exhale }
+    annotation_keyword = _{ pre | post | invariant | assertion | inhale | exhale | fold | unfold }
         pre = { "requires" }
         post = { "ensures" }
         invariant = { "invariant" }
         assertion = { "assert" }
         inhale = { "inhale" }
         exhale = { "exhale" }
+        fold = { "fold" }
+        unfold = { "unfold" }
 
 // TODO: change "/*" ~ "@" to "/*@" when Pancake parsing fixed
 predicate = { "/*" ~ "@" ~ "predicate" ~ ident ~ "(" ~ pred_args ~ ")" ~ pred_body ~ "@"? ~ "*/" }

--- a/pancake2viper/src/annotation/annot.pest
+++ b/pancake2viper/src/annotation/annot.pest
@@ -41,7 +41,7 @@ expr = !{ prefix? ~ primary ~ postfix? ~ (infix ~ prefix? ~ primary ~ postfix?)*
             field_idx = !{ integer }
         arr_acc = @{ "[" ~ expr ~ "]" }
 
-    primary = _{ "(" ~ expr ~ ")" | int_lit | quantified | acc_pred | f_call | field_acc | ident }
+    primary = _{ "(" ~ expr ~ ")" | unfolding | int_lit | quantified | acc_pred | f_call | field_acc | ident }
 
         quantified = { (forall | exists) ~ decl ~ ("," ~ decl)* ~ "::" ~ triggers ~ expr }
             forall = { "forall" }
@@ -57,6 +57,7 @@ expr = !{ prefix? ~ primary ~ postfix? ~ (infix ~ prefix? ~ primary ~ postfix?)*
                 perm_var = { ident }
 
         f_call = {ident ~ "(" ~ (expr ~ ("," ~ expr)* | "") ~ ")" }
+        unfolding = { "unfolding" ~ f_call ~ "in" ~ expr }
 
 
 annotation = {"@"? ~ WHITESPACE* ~ annotation_keyword ~ expr ~ WHITESPACE* ~ "@"? }

--- a/pancake2viper/src/annotation/annot.pest
+++ b/pancake2viper/src/annotation/annot.pest
@@ -36,11 +36,12 @@ expr = !{ prefix? ~ primary ~ postfix? ~ (infix ~ prefix? ~ primary ~ postfix?)*
         neg = { "!" }
         minus = { "-" }
     
-    postfix = _{ field_acc }
+    postfix = _{ field_acc | arr_acc }
         field_acc = @{ ("." ~ field_idx)+ }
             field_idx = !{ integer }
+        arr_acc = @{ "[" ~ expr ~ "]" }
 
-    primary = _{ "(" ~ expr ~ ")" | int_lit | quantified | acc_pred | f_call | heap | field_acc | ident }
+    primary = _{ "(" ~ expr ~ ")" | int_lit | quantified | acc_pred | f_call | field_acc | ident }
 
         quantified = { (forall | exists) ~ decl ~ ("," ~ decl)* ~ "::" ~ triggers ~ expr }
             forall = { "forall" }
@@ -56,7 +57,6 @@ expr = !{ prefix? ~ primary ~ postfix? ~ (infix ~ prefix? ~ primary ~ postfix?)*
                 perm_var = { ident }
 
         f_call = {ident ~ "(" ~ (expr ~ ("," ~ expr)* | "") ~ ")" }
-        heap = { "heap[" ~ expr ~ "]" }
 
 
 annotation = {"@"? ~ WHITESPACE* ~ annotation_keyword ~ expr ~ WHITESPACE* ~ "@"? }

--- a/pancake2viper/src/annotation/annot.pest
+++ b/pancake2viper/src/annotation/annot.pest
@@ -58,12 +58,17 @@ expr = !{ prefix? ~ primary ~ postfix? ~ (infix ~ prefix? ~ primary ~ postfix?)*
         f_call = {ident ~ "(" ~ (expr ~ ("," ~ expr)* | "") ~ ")" }
         heap = { "heap[" ~ expr ~ "]" }
 
-top_keywords = _{ pre | post | invariant | assertion | inhale | exhale }
-    pre = { "requires" }
-    post = { "ensures" }
-    invariant = { "invariant" }
-    assertion = { "assert" }
-    inhale = { "inhale" }
-    exhale = { "exhale" }
 
-top = {"@"? ~ WHITESPACE* ~ top_keywords ~ expr ~ WHITESPACE* ~ "@"? }
+annotation = {"@"? ~ WHITESPACE* ~ annotation_keyword ~ expr ~ WHITESPACE* ~ "@"? }
+    annotation_keyword = _{ pre | post | invariant | assertion | inhale | exhale }
+        pre = { "requires" }
+        post = { "ensures" }
+        invariant = { "invariant" }
+        assertion = { "assert" }
+        inhale = { "inhale" }
+        exhale = { "exhale" }
+
+// TODO: change "/*" ~ "@" to "/*@" when Pancake parsing fixed
+predicate = { "/*" ~ "@" ~ "predicate" ~ ident ~ "(" ~ pred_args ~ ")" ~ pred_body ~ "@"? ~ "*/" }
+    pred_args = { (decl ~ ("," ~ decl)*) | "" }
+    pred_body = { ("{" ~ expr ~ "}") | "" }

--- a/pancake2viper/src/annotation/mod.rs
+++ b/pancake2viper/src/annotation/mod.rs
@@ -2,4 +2,4 @@ mod parser;
 #[cfg(test)]
 mod tests;
 
-pub use parser::parse_annot;
+pub use parser::{parse_annot, parse_predicate};

--- a/pancake2viper/src/annotation/parser.rs
+++ b/pancake2viper/src/annotation/parser.rs
@@ -25,7 +25,7 @@ lazy_static::lazy_static! {
 }
 
 pub fn parse_annot(annot: &str) -> Annotation {
-    match AnnotParser::parse(Rule::top, annot) {
+    match AnnotParser::parse(Rule::annotation, annot) {
         Ok(mut pairs) => {
             let mut pair = pairs.next().unwrap().into_inner();
             let typ = pair.next().unwrap();
@@ -34,6 +34,29 @@ pub fn parse_annot(annot: &str) -> Annotation {
                 typ: AnnotationType::from_pest(typ),
                 expr: parse_expr(Pairs::single(expr)),
             }
+        }
+        Err(e) => panic!("{:?}", e),
+    }
+}
+
+pub fn parse_predicate(pred: &str) -> Predicate {
+    match AnnotParser::parse(Rule::predicate, pred) {
+        Ok(mut pairs) => {
+            let mut pair = pairs.next().unwrap().into_inner();
+            let name = pair.next().unwrap().as_str().to_owned();
+            let args = pair
+                .next()
+                .unwrap()
+                .into_inner()
+                .map(Decl::from_pest)
+                .collect();
+            let body = pair.next().unwrap().into_inner();
+            let body = if body.len() == 0 {
+                None
+            } else {
+                Some(parse_expr(body))
+            };
+            Predicate { name, args, body }
         }
         Err(e) => panic!("{:?}", e),
     }

--- a/pancake2viper/src/annotation/parser.rs
+++ b/pancake2viper/src/annotation/parser.rs
@@ -114,6 +114,8 @@ impl FromPestPair for AnnotationType {
             Rule::invariant => Self::Invariant,
             Rule::inhale => Self::Inhale,
             Rule::exhale => Self::Exhale,
+            Rule::fold => Self::Fold,
+            Rule::unfold => Self::Unfold,
             x => panic!("Failed to parse AnnotationType, got {:?}", x),
         }
     }

--- a/pancake2viper/src/annotation/parser.rs
+++ b/pancake2viper/src/annotation/parser.rs
@@ -142,7 +142,7 @@ impl FromPestPair for Type {
     }
 }
 
-impl FromPestPair for QuantifiedDecl {
+impl FromPestPair for Decl {
     fn from_pest(pair: Pair<'_, Rule>) -> Self {
         match pair.as_rule() {
             Rule::decl => {
@@ -179,7 +179,7 @@ impl FromPestPair for Quantified {
         let decls = pairs
             .clone()
             .take(decl_amount)
-            .map(|d| QuantifiedDecl::from_pest(d))
+            .map(|d| Decl::from_pest(d))
             .collect();
         let mut pairs = pairs.skip(decl_amount);
         let triggers = pairs

--- a/pancake2viper/src/ir/expression.rs
+++ b/pancake2viper/src/ir/expression.rs
@@ -139,7 +139,7 @@ pub enum Type {
 }
 
 #[derive(Debug, Clone)]
-pub struct QuantifiedDecl {
+pub struct Decl {
     pub name: String,
     pub typ: Type,
 }
@@ -153,7 +153,7 @@ pub enum Quantifier {
 #[derive(Debug, Clone)]
 pub struct Quantified {
     pub quantifier: Quantifier,
-    pub decls: Vec<QuantifiedDecl>,
+    pub decls: Vec<Decl>,
     pub triggers: Vec<Expr>,
     pub body: Box<Expr>,
 }

--- a/pancake2viper/src/ir/expression.rs
+++ b/pancake2viper/src/ir/expression.rs
@@ -19,7 +19,7 @@ pub enum Expr {
     MethodCall(MethodCall),
     FunctionCall(FunctionCall),
     Quantified(Quantified),
-    HeapAccess(HeapAccess),
+    ArrayAccess(ArrayAccess),
     AccessPredicate(AccessPredicate),
     FieldAccessChain(FieldAccessChain),
 }
@@ -159,7 +159,8 @@ pub struct Quantified {
 }
 
 #[derive(Debug, Clone)]
-pub struct HeapAccess {
+pub struct ArrayAccess {
+    pub obj: Box<Expr>,
     pub idx: Box<Expr>,
 }
 

--- a/pancake2viper/src/ir/expression.rs
+++ b/pancake2viper/src/ir/expression.rs
@@ -22,6 +22,7 @@ pub enum Expr {
     ArrayAccess(ArrayAccess),
     AccessPredicate(AccessPredicate),
     FieldAccessChain(FieldAccessChain),
+    UnfoldingIn(UnfoldingIn),
 }
 
 #[derive(Debug, Clone)]
@@ -168,4 +169,10 @@ pub struct ArrayAccess {
 pub struct FieldAccessChain {
     pub obj: Box<Expr>,
     pub idxs: Vec<usize>,
+}
+
+#[derive(Debug, Clone)]
+pub struct UnfoldingIn {
+    pub pred: Box<Expr>,
+    pub expr: Box<Expr>,
 }

--- a/pancake2viper/src/ir/statement.rs
+++ b/pancake2viper/src/ir/statement.rs
@@ -126,6 +126,8 @@ pub enum AnnotationType {
     Invariant,
     Inhale,
     Exhale,
+    Fold,
+    Unfold,
 }
 
 #[derive(Debug, Clone)]

--- a/pancake2viper/src/ir/toplevel.rs
+++ b/pancake2viper/src/ir/toplevel.rs
@@ -1,4 +1,4 @@
-use super::Stmt;
+use super::{Decl, Expr, Stmt};
 use crate::{ir_to_viper::ViperEncodeCtx, shape::Shape, ToShape};
 
 #[derive(Debug, Clone)]
@@ -24,6 +24,14 @@ pub struct Arg {
 }
 
 #[derive(Debug, Clone)]
+pub struct Predicate {
+    pub name: String,
+    pub args: Vec<Decl>,
+    pub body: Option<Expr>,
+}
+
+#[derive(Debug, Clone)]
 pub struct Program {
     pub functions: Vec<FnDec>,
+    pub predicates: Vec<Predicate>,
 }

--- a/pancake2viper/src/ir_to_viper/expression.rs
+++ b/pancake2viper/src/ir_to_viper/expression.rs
@@ -279,18 +279,17 @@ impl<'a> ToViper<'a> for ir::FunctionCall {
     type Output = viper::Expr<'a>;
     fn to_viper(self, ctx: &mut ViperEncodeCtx<'a>) -> Self::Output {
         let ast = ctx.ast;
-        // FIXME: return type
+        let args = self.args.to_viper(ctx);
         match self.fname.as_str() {
             "alen" => {
-                let arr = self.args[0].clone().to_viper(ctx);
+                let arr = args[0];
                 ctx.iarray.len_f(arr)
             }
-            fname => ast.func_app(
-                fname,
-                &self.args.to_viper(ctx),
-                ast.int_type(),
-                ast.no_position(),
-            ),
+            pred if ctx.is_predicate(pred) => {
+                ast.predicate_access_predicate(ast.predicate_access(&args, pred), ast.full_perm())
+            }
+            // FIXME: return type
+            fname => ast.func_app(fname, &args, ast.int_type(), ast.no_position()),
         }
     }
 }

--- a/pancake2viper/src/ir_to_viper/expression.rs
+++ b/pancake2viper/src/ir_to_viper/expression.rs
@@ -279,13 +279,14 @@ impl<'a> ToViper<'a> for ir::FunctionCall {
     type Output = viper::Expr<'a>;
     fn to_viper(self, ctx: &mut ViperEncodeCtx<'a>) -> Self::Output {
         let ast = ctx.ast;
-        let args = self.args.to_viper(ctx);
+        let mut args = self.args.to_viper(ctx);
         match self.fname.as_str() {
             "alen" => {
                 let arr = args[0];
                 ctx.iarray.len_f(arr)
             }
             pred if ctx.is_predicate(pred) => {
+                args.insert(0, ctx.heap_var().1);
                 ast.predicate_access_predicate(ast.predicate_access(&args, pred), ast.full_perm())
             }
             // FIXME: return type

--- a/pancake2viper/src/ir_to_viper/expression.rs
+++ b/pancake2viper/src/ir_to_viper/expression.rs
@@ -395,6 +395,14 @@ impl<'a> ToViper<'a> for ir::FieldAccessChain {
     }
 }
 
+impl<'a> ToViper<'a> for ir::UnfoldingIn {
+    type Output = viper::Expr<'a>;
+    fn to_viper(self, ctx: &mut ViperEncodeCtx<'a>) -> Self::Output {
+        let ast = ctx.ast;
+        ast.unfolding(self.pred.to_viper(ctx), self.expr.to_viper(ctx))
+    }
+}
+
 impl<'a> ToViper<'a> for ir::Expr {
     type Output = viper::Expr<'a>;
     fn to_viper(self, ctx: &mut ViperEncodeCtx<'a>) -> Self::Output {
@@ -422,6 +430,7 @@ impl<'a> ToViper<'a> for ir::Expr {
             ArrayAccess(heap) => heap.to_viper(ctx),
             AccessPredicate(acc) => acc.to_viper(ctx),
             FieldAccessChain(f) => f.to_viper(ctx),
+            UnfoldingIn(u) => u.to_viper(ctx),
         }
     }
 }
@@ -440,6 +449,7 @@ impl<'a> ToShape<'a> for ir::Expr {
             Load(load) => load.shape.clone(),
             Field(field) => field.shape(ctx),
             Struct(struc) => struc.shape(ctx),
+            UnfoldingIn(unfold) => unfold.expr.shape(ctx),
         }
     }
 }

--- a/pancake2viper/src/ir_to_viper/expression.rs
+++ b/pancake2viper/src/ir_to_viper/expression.rs
@@ -237,12 +237,12 @@ impl<'a> ToViperType<'a> for ir::Type {
     }
 }
 
-impl<'a> ToViper<'a> for ir::QuantifiedDecl {
+impl<'a> ToViper<'a> for ir::Decl {
     type Output = viper::LocalVarDecl<'a>;
     fn to_viper(self, ctx: &mut ViperEncodeCtx<'a>) -> Self::Output {
         let ast = ctx.ast;
         ctx.set_type(self.name.clone(), Shape::Simple);
-        ctx.mangler.insert_annot_var(self.name.clone());
+        ctx.mangler.new_annot_var(self.name.clone());
         ast.local_var_decl(&self.name, self.typ.to_viper_type(ctx))
     }
 }
@@ -432,21 +432,5 @@ impl<'a> ToShape<'a> for ir::Expr {
             Field(field) => field.shape(ctx),
             Struct(struc) => struc.shape(ctx),
         }
-    }
-}
-
-impl<'a> ToViper<'a> for Vec<ir::Expr> {
-    type Output = Vec<viper::Expr<'a>>;
-    fn to_viper(self, ctx: &mut ViperEncodeCtx<'a>) -> Self::Output {
-        self.into_iter()
-            .map(|a| a.to_viper(ctx))
-            .collect::<Vec<_>>()
-    }
-}
-
-impl<'a, const T: usize> ToViper<'a> for [ir::Expr; T] {
-    type Output = [viper::Expr<'a>; T];
-    fn to_viper(self, ctx: &mut ViperEncodeCtx<'a>) -> Self::Output {
-        self.map(|e| e.to_viper(ctx))
     }
 }

--- a/pancake2viper/src/ir_to_viper/statement.rs
+++ b/pancake2viper/src/ir_to_viper/statement.rs
@@ -201,7 +201,10 @@ impl<'a> ToViper<'a> for ir::Annotation {
                         Fold => ast.fold(e),
                         _ => unreachable!(),
                     };
-                    ast_node(ast.predicate_access(&access.args.to_viper(ctx), &access.fname))
+                    ast_node(ast.predicate_access_predicate(
+                        ast.predicate_access(&access.args.to_viper(ctx), &access.fname),
+                        ast.full_perm(),
+                    ))
                 }
                 _ => panic!(
                     "Invalid Fold/Unfold. Expected predicate access, got {:?}",

--- a/pancake2viper/src/ir_to_viper/statement.rs
+++ b/pancake2viper/src/ir_to_viper/statement.rs
@@ -201,8 +201,10 @@ impl<'a> ToViper<'a> for ir::Annotation {
                         Fold => ast.fold(e),
                         _ => unreachable!(),
                     };
+                    let mut args = access.args.to_viper(ctx);
+                    args.insert(0, ctx.heap_var().1);
                     ast_node(ast.predicate_access_predicate(
-                        ast.predicate_access(&access.args.to_viper(ctx), &access.fname),
+                        ast.predicate_access(&args, &access.fname),
                         ast.full_perm(),
                     ))
                 }

--- a/pancake2viper/src/ir_to_viper/toplevel.rs
+++ b/pancake2viper/src/ir_to_viper/toplevel.rs
@@ -81,11 +81,10 @@ impl<'a> ToViper<'a> for Predicate {
     type Output = viper::Predicate<'a>;
     fn to_viper(self, ctx: &mut ViperEncodeCtx<'a>) -> Self::Output {
         let ast = ctx.ast;
-        ast.predicate(
-            &self.name,
-            &self.args.to_viper(ctx),
-            self.body.map(|e| e.to_viper(ctx)),
-        )
+        let mut args = self.args.to_viper(ctx);
+        let body = self.body.map(|e| e.to_viper(ctx));
+        args.insert(0, ctx.heap_var().0);
+        ast.predicate(&self.name, &args, body)
     }
 }
 

--- a/pancake2viper/src/ir_to_viper/utils/context.rs
+++ b/pancake2viper/src/ir_to_viper/utils/context.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use viper::{AstFactory, Declaration, LocalVarDecl};
 
@@ -47,6 +47,7 @@ pub struct ViperEncodeCtx<'a> {
     pub pres: Vec<viper::Expr<'a>>,
     pub posts: Vec<viper::Expr<'a>>,
     pub invariants: Vec<viper::Expr<'a>>,
+    predicates: HashSet<String>,
 }
 
 #[derive(Clone, Copy)]
@@ -65,7 +66,12 @@ impl Default for EncodeOptions {
 }
 
 impl<'a> ViperEncodeCtx<'a> {
-    pub fn new(fname: String, ast: AstFactory<'a>, options: EncodeOptions) -> Self {
+    pub fn new(
+        fname: String,
+        predicates: HashSet<String>,
+        ast: AstFactory<'a>,
+        options: EncodeOptions,
+    ) -> Self {
         let mut type_map = HashMap::new();
         for &keyword in RESERVED.iter() {
             type_map.insert(keyword.into(), Shape::Simple);
@@ -84,6 +90,7 @@ impl<'a> ViperEncodeCtx<'a> {
             pres: vec![],
             posts: vec![],
             invariants: vec![],
+            predicates,
         }
     }
 
@@ -101,6 +108,7 @@ impl<'a> ViperEncodeCtx<'a> {
             pres: self.pres.clone(),
             posts: self.posts.clone(),
             invariants: self.invariants.clone(),
+            predicates: self.predicates.clone(),
         }
     }
 
@@ -173,5 +181,9 @@ impl<'a> ViperEncodeCtx<'a> {
 
     pub fn get_mode(&self) -> TranslationMode {
         self.mode
+    }
+
+    pub fn is_predicate(&self, ident: &str) -> bool {
+        self.predicates.contains(ident)
     }
 }

--- a/pancake2viper/src/ir_to_viper/utils/mangler.rs
+++ b/pancake2viper/src/ir_to_viper/utils/mangler.rs
@@ -88,6 +88,9 @@ impl Mangler {
     }
 
     pub fn mangle_var<'a>(&'a self, var: &'a str) -> &'a str {
+        if RESERVED.contains(var) {
+            return var;
+        }
         if let TranslationMode::PrePost = self.mode {
             if let Some(ret) = self.args.get(var) {
                 return ret;
@@ -95,9 +98,6 @@ impl Mangler {
         }
 
         if let TranslationMode::PrePost | TranslationMode::Assertion = self.mode {
-            if RESERVED.contains(var) {
-                return var;
-            }
             if let Some(ret) = self.annot_vars.get(var) {
                 return ret;
             }

--- a/pancake2viper/src/ir_to_viper/utils/mangler.rs
+++ b/pancake2viper/src/ir_to_viper/utils/mangler.rs
@@ -89,15 +89,15 @@ impl Mangler {
 
     pub fn mangle_var<'a>(&'a self, var: &'a str) -> &'a str {
         if let TranslationMode::PrePost = self.mode {
-            if RESERVED.contains(var) {
-                return var;
-            }
             if let Some(ret) = self.args.get(var) {
                 return ret;
             }
         }
 
         if let TranslationMode::PrePost | TranslationMode::Assertion = self.mode {
+            if RESERVED.contains(var) {
+                return var;
+            }
             if let Some(ret) = self.annot_vars.get(var) {
                 return ret;
             }

--- a/pancake2viper/src/ir_to_viper/utils/mangler.rs
+++ b/pancake2viper/src/ir_to_viper/utils/mangler.rs
@@ -57,7 +57,7 @@ impl Mangler {
         mangled
     }
 
-    pub fn insert_annot_var(&mut self, var: String) {
+    pub fn new_annot_var(&mut self, var: String) {
         assert!(
             self.annot_vars.insert(var.clone()),
             "Duplicated variable in annotation: '{}'\n{:?}",

--- a/pancake2viper/src/ir_to_viper/utils/mod.rs
+++ b/pancake2viper/src/ir_to_viper/utils/mod.rs
@@ -4,3 +4,21 @@ mod mangler;
 
 pub use context::*;
 pub use mangler::*;
+
+use crate::ToViper;
+
+impl<'a, T: ToViper<'a>> ToViper<'a> for Vec<T> {
+    type Output = Vec<T::Output>;
+    fn to_viper(self, ctx: &mut ViperEncodeCtx<'a>) -> Self::Output {
+        self.into_iter()
+            .map(|a| a.to_viper(ctx))
+            .collect::<Vec<_>>()
+    }
+}
+
+impl<'a, const T: usize, S: ToViper<'a>> ToViper<'a> for [S; T] {
+    type Output = [S::Output; T];
+    fn to_viper(self, ctx: &mut ViperEncodeCtx<'a>) -> Self::Output {
+        self.map(|e| e.to_viper(ctx))
+    }
+}

--- a/pancake2viper/src/pancake/toplevel.rs
+++ b/pancake2viper/src/pancake/toplevel.rs
@@ -15,6 +15,12 @@ pub struct Arg {
 }
 
 #[derive(Debug, Clone)]
+pub struct Predicate {
+    pub text: String,
+}
+
+#[derive(Debug, Clone)]
 pub struct Program {
     pub functions: Vec<FnDec>,
+    pub predicates: Vec<Predicate>,
 }

--- a/pancake2viper/src/pancake_to_ir/toplevel.rs
+++ b/pancake2viper/src/pancake_to_ir/toplevel.rs
@@ -1,4 +1,4 @@
-use crate::{ir, pancake};
+use crate::{annotation::parse_predicate, ir, pancake};
 
 use super::utils::Wrapper;
 
@@ -22,11 +22,20 @@ impl From<pancake::FnDec> for ir::FnDec {
     }
 }
 
+impl From<pancake::Predicate> for ir::Predicate {
+    fn from(value: pancake::Predicate) -> Self {
+        parse_predicate(&value.text)
+    }
+}
+
 impl From<pancake::Program> for ir::Program {
     fn from(value: pancake::Program) -> Self {
         let functions: Wrapper<ir::FnDec> = value.functions.into();
+        // let predicates: Wrapper<ir::Predicate> = value.predicates.into(); XXX: wtf?
+        let predicates = value.predicates.into_iter().map(|e| e.into()).collect();
         Self {
             functions: functions.0,
+            predicates,
         }
     }
 }

--- a/pancake2viper/tests/acc_predicate.pnk
+++ b/pancake2viper/tests/acc_predicate.pnk
@@ -1,9 +1,0 @@
-/* @ 
-    predicate full_access(a: IArray) {
-        forall j: Int :: 0 <= j && j < alen(a) ==> acc(a[j])
-    } 
-@*/
-fun main(2 x) {
-    /*@ fold full_access(x) @*/
-    return 0;
-}

--- a/pancake2viper/tests/acc_predicate.pnk
+++ b/pancake2viper/tests/acc_predicate.pnk
@@ -1,0 +1,9 @@
+/* @ 
+    predicate full_access(a: IArray) {
+        forall j: Int :: 0 <= j && j < alen(a) ==> acc(a[j])
+    } 
+@*/
+fun main(2 x) {
+    /*@ fold full_access(x) @*/
+    return 0;
+}

--- a/pancake2viper/tests/predicate.pnk
+++ b/pancake2viper/tests/predicate.pnk
@@ -1,6 +1,11 @@
+/* @ 
+    predicate full_acc(a: IArray) {
+        forall j: Int :: 0 <= j && j < alen(a) ==> acc(a[j])
+    } 
+@*/
 /* @ predicate P(a: Int) { a == 0 } @*/
 fun main(2 x) {
-    // /*@ fold full_acc(x) @*/
+    /*@ fold full_acc(x) @*/
     var y = 0;
     /*@ assert y == 0 @*/
     /*@ fold P(y) @*/

--- a/pancake2viper/tests/predicate.pnk
+++ b/pancake2viper/tests/predicate.pnk
@@ -1,0 +1,9 @@
+/* @ predicate P(a: Int) { a == 0 } @*/
+fun main(2 x) {
+    // /*@ fold full_acc(x) @*/
+    var y = 0;
+    /*@ assert y == 0 @*/
+    /*@ fold P(y) @*/
+    /*@ assert y == 0 @*/
+    return 0;
+}

--- a/pancake2viper/tests/predicate_heap.pnk
+++ b/pancake2viper/tests/predicate_heap.pnk
@@ -1,0 +1,13 @@
+/* @ predicate IO() {
+    acc(heap[42])
+} @*/
+
+fun main() {
+    /*@ requires IO() @*/
+    /*@ ensures IO() @*/
+
+    /*@ unfold IO() @*/
+    st @base + 42 * 8, 1337;
+    /*@ fold IO() @*/
+    return 0;
+}

--- a/pancake2viper/tests/predicate_in_precondition.pnk
+++ b/pancake2viper/tests/predicate_in_precondition.pnk
@@ -1,0 +1,16 @@
+/* @ predicate P(a: Int) { a == 0 } @*/
+
+fun main() {
+    var y = 0;
+    /*@ fold P(y) @*/
+    do_stuff(y);
+    return 0;
+}
+
+fun do_stuff(1 x) {
+    /*@ requires P(x) @*/
+
+    /*@ unfold P(x) @*/
+    /*@ assert x == 0 @*/
+    return 0;
+}

--- a/pancake2viper/tests/predicate_unfolding_in.pnk
+++ b/pancake2viper/tests/predicate_unfolding_in.pnk
@@ -8,9 +8,9 @@ fun main() {
     /*@ requires unfolding IO() in heap[42] == 17 @*/
     /*@ ensures unfolding IO() in heap[42] == 1337 @*/
 
-    /*@ unfold IO(heap) @*/
+    /*@ unfold IO() @*/
     /*@ assert heap[42] == 17 @*/
     st @base + 42 * 8, 1337;
-    /*@ fold IO(heap) @*/
+    /*@ fold IO() @*/
     return 0;
 }

--- a/pancake2viper/tests/predicate_unfolding_in.pnk
+++ b/pancake2viper/tests/predicate_unfolding_in.pnk
@@ -1,0 +1,16 @@
+/* @ predicate IO() {
+    acc(heap[42])
+} @*/
+
+fun main() {
+    /*@ requires IO() @*/
+    /*@ ensures IO() @*/
+    /*@ requires unfolding IO() in heap[42] == 17 @*/
+    /*@ ensures unfolding IO() in heap[42] == 1337 @*/
+
+    /*@ unfold IO(heap) @*/
+    /*@ assert heap[42] == 17 @*/
+    st @base + 42 * 8, 1337;
+    /*@ fold IO(heap) @*/
+    return 0;
+}


### PR DESCRIPTION
 - adds array access syntax to every variable (not only `heap`) in annotations: `acc(some_array[0]`
 -  definitions of predicates in top-level annotations: `/* @ predicate P(a: Int) { a == 0 } @*/`
 - fold/unfold statements as annotations `/*@ fold P(x) @*/`
 - predicates in method pre/postconditions: `/*@ requires P(x) @*/`
 - heap arg automatically added to predicates: `/*@ fold P(x) @*/` -> `fold P(heap, x)`
 - unfolding in expression implemented: `/*@ requires unfolding IO() in heap[42] == 17 @*/`
 - closes #12 