### PR TITLE
Add missing keywords and operators to annotations

### DIFF
--- a/pancake2viper/src/annotation/annot.pest
+++ b/pancake2viper/src/annotation/annot.pest
@@ -11,7 +11,7 @@ decl = { ident ~ ":" ~ type }
 
 int_lit = @{ "-"? ~ integer}
 
-bin_op = _{ add | sub | mul | div | modulo | imp | iff | viper_eq | viper_neq | pancake_eq | pancake_neq | gte | gt | lte | lt | bool_or | bool_and }
+bin_op = _{ add | sub | mul | div | modulo | imp | iff | viper_eq | viper_neq | pancake_eq | pancake_neq | gte | gt | lte | lt | bool_or | bool_and | bit_and | bit_or | bit_xor }
     add = { "+" }
     sub = { "-" }
     mul = { "*" }
@@ -29,6 +29,9 @@ bin_op = _{ add | sub | mul | div | modulo | imp | iff | viper_eq | viper_neq | 
     lte = { "<=" }
     bool_and = { "&&" }
     bool_or = { "||" }
+    bit_and = { "&" }
+    bit_or = { "|" }
+    bit_xor = { "^" }
 
 expr = !{ prefix? ~ primary ~ postfix? ~ (infix ~ prefix? ~ primary ~ postfix?)* }
     infix = _{ bin_op }
@@ -42,7 +45,7 @@ expr = !{ prefix? ~ primary ~ postfix? ~ (infix ~ prefix? ~ primary ~ postfix?)*
         arr_acc = @{ "[" ~ expr ~ "]" }
         ternary = { "?" ~ expr ~ ":" ~ expr }
 
-    primary = _{ "(" ~ expr ~ ")" | unfolding | int_lit | quantified | acc_pred | f_call | field_acc | ident }
+    primary = _{ "(" ~ expr ~ ")" | unfolding | int_lit | quantified | acc_pred | f_call | field_acc | ident | biw | base }
 
         quantified = { (forall | exists) ~ decl ~ ("," ~ decl)* ~ "::" ~ triggers ~ expr }
             forall = { "forall" }
@@ -59,6 +62,8 @@ expr = !{ prefix? ~ primary ~ postfix? ~ (infix ~ prefix? ~ primary ~ postfix?)*
 
         f_call = {ident ~ "(" ~ (expr ~ ("," ~ expr)* | "") ~ ")" }
         unfolding = { "unfolding" ~ f_call ~ "in" ~ expr }
+        biw = { "@biw" }
+        base = { "@base" }
 
 annotation_comment = _{"@"? ~ WHITESPACE* ~ annotation ~ WHITESPACE* ~ "@"? }
 annotation = { annotation_keyword ~ expr }

--- a/pancake2viper/src/annotation/annot.pest
+++ b/pancake2viper/src/annotation/annot.pest
@@ -39,11 +39,16 @@ expr = !{ prefix? ~ primary ~ postfix? ~ (infix ~ prefix? ~ primary ~ postfix?)*
         neg = { "!" }
         minus = { "-" }
     
-    postfix = _{ field_acc | arr_acc | ternary }
+    postfix = _{ field_acc | arr_acc | ternary | shift }
         field_acc = @{ ("." ~ field_idx)+ }
             field_idx = !{ integer }
         arr_acc = @{ "[" ~ expr ~ "]" }
         ternary = { "?" ~ expr ~ ":" ~ expr }
+        shift = { shift_type ~ int_lit }
+            shift_type = _{ lshr | ashr | lshl }
+                lshr = { ">>>" }
+                ashr = { ">>" }
+                lshl = { "<<" }
 
     primary = _{ "(" ~ expr ~ ")" | unfolding | int_lit | quantified | acc_pred | f_call | field_acc | ident | biw | base }
 

--- a/pancake2viper/src/annotation/parser.rs
+++ b/pancake2viper/src/annotation/parser.rs
@@ -13,9 +13,12 @@ lazy_static::lazy_static! {
         use pest::pratt_parser::{Assoc::*, Op};
         PrattParser::new()
             .op(Op::infix(Rule::imp, Right) | Op::infix(Rule::iff, Left))
-            .op(Op::infix(Rule::pancake_eq, Left) | Op::infix(Rule::pancake_neq, Left) | Op::infix(Rule::viper_eq, Left) | Op::infix(Rule::viper_neq, Left))
             .op(Op::infix(Rule::bool_or, Left))
             .op(Op::infix(Rule::bool_and, Left))
+            .op(Op::infix(Rule::bit_or, Left))
+            .op(Op::infix(Rule::bit_xor, Left))
+            .op(Op::infix(Rule::bit_and, Left))
+            .op(Op::infix(Rule::pancake_eq, Left) | Op::infix(Rule::pancake_neq, Left) | Op::infix(Rule::viper_eq, Left) | Op::infix(Rule::viper_neq, Left))
             .op(Op::infix(Rule::gt, Left) | Op::infix(Rule::gte, Left) | Op::infix(Rule::lt, Left) | Op::infix(Rule::lte, Left))
             .op(Op::infix(Rule::add, Left) | Op::infix(Rule::sub, Left))
             .op(Op::infix(Rule::mul, Left) | Op::infix(Rule::div, Left) | Op::infix(Rule::modulo, Left))
@@ -119,6 +122,8 @@ pub fn parse_expr(pairs: Pairs<Rule>) -> Expr {
             Rule::f_call => Expr::FunctionCall(FunctionCall::from_pest(primary)),
             Rule::acc_pred => Expr::AccessPredicate(AccessPredicate::from_pest(primary)),
             Rule::unfolding => Expr::UnfoldingIn(UnfoldingIn::from_pest(primary)),
+            Rule::base => Expr::BaseAddr,
+            Rule::biw => Expr::BytesInWord,
             x => panic!("Unexpected annotation parsing rule: {:?}", x),
         })
         .map_prefix(|op, rhs| {
@@ -212,6 +217,9 @@ impl FromPestPair for BinOpType {
             Rule::lte => Self::Lte,
             Rule::bool_and => Self::BoolAnd,
             Rule::bool_or => Self::BoolOr,
+            Rule::bit_and => Self::BitAnd,
+            Rule::bit_or => Self::BitOr,
+            Rule::bit_xor => Self::BitXor,
             x => panic!("Failed to parse BinOperator, got {:?}", x),
         }
     }

--- a/pancake2viper/src/annotation/parser.rs
+++ b/pancake2viper/src/annotation/parser.rs
@@ -13,6 +13,7 @@ lazy_static::lazy_static! {
         use pest::pratt_parser::{Assoc::*, Op};
         PrattParser::new()
             .op(Op::infix(Rule::imp, Right) | Op::infix(Rule::iff, Left))
+            .op(Op::postfix(Rule::ternary))
             .op(Op::infix(Rule::bool_or, Left))
             .op(Op::infix(Rule::bool_and, Left))
             .op(Op::infix(Rule::bit_or, Left))
@@ -23,7 +24,6 @@ lazy_static::lazy_static! {
             .op(Op::infix(Rule::add, Left) | Op::infix(Rule::sub, Left))
             .op(Op::infix(Rule::mul, Left) | Op::infix(Rule::div, Left) | Op::infix(Rule::modulo, Left))
             .op(Op::prefix(Rule::neg) | Op::prefix(Rule::minus))
-            .op(Op::postfix(Rule::ternary))
             .op(Op::postfix(Rule::field_acc))
             .op(Op::postfix(Rule::arr_acc))
     };

--- a/pancake2viper/tests/annot_missing_keywords.pnk
+++ b/pancake2viper/tests/annot_missing_keywords.pnk
@@ -1,0 +1,14 @@
+fun access_ptr(1 ptr) {
+    /*@ requires ptr % 8 == 0 @*/
+    /*@ requires acc(heap[ptr/@biw]) @*/
+    /*@ ensures acc(heap[ptr/@biw]) @*/
+
+    st @base + ptr, 1337;
+    return 0;
+}
+
+fun t() {
+    /*@ assert @base == 0 @*/
+    /*@ assert (3 & 2) == 2 @*/
+    return 0;
+}

--- a/pancake2viper/tests/annot_missing_keywords.pnk
+++ b/pancake2viper/tests/annot_missing_keywords.pnk
@@ -10,5 +10,7 @@ fun access_ptr(1 ptr) {
 fun t() {
     /*@ assert @base == 0 @*/
     /*@ assert (3 & 2) == 2 @*/
+    /*@ assert (1337 >> 4) == (1337 >>> 4) @*/
+    /*@ assert (1024 >> 2) == (64 << 2) @*/
     return 0;
 }

--- a/pancake2viper/tests/array_sum.pnk
+++ b/pancake2viper/tests/array_sum.pnk
@@ -3,7 +3,7 @@
     requires base + len <= alen(heap)
     requires forall i: Int :: base <= i && i < base + len ==> acc(heap[i], read)
 {
-    (len == 0) ? 0 : (heap[base + len - 1] + sum(heap, base, len - 1))
+    len == 0 ? 0 : (heap[base + len - 1] + sum(heap, base, len - 1))
 } @*/
 
 fun array_sum(1 arr, 1 len) {


### PR DESCRIPTION
Missing operators in annotations:
 - [X] bytes in word and base address: @biw, @base (fixes #30)
 - [X] bitwise and, or, xor: &, |, ^
 - [x] shift operators: <<, >>, >>>