### PR TITLE
fixed parsing of calls as expressions

### DIFF
--- a/pancake2viper/src/pancake/expression.rs
+++ b/pancake2viper/src/pancake/expression.rs
@@ -77,7 +77,6 @@ pub struct Shift {
 
 #[derive(Debug, Clone)]
 pub struct ExprCall {
-    pub expected_rettype: Shape,
     pub fname: Box<Expr>,
     pub args: Vec<Expr>,
 }

--- a/pancake2viper/src/pancake/parser.rs
+++ b/pancake2viper/src/pancake/parser.rs
@@ -98,16 +98,14 @@ impl Expr {
             })),
             [Symbol(base)] if base == "BaseAddr" => Ok(Self::BaseAddr),
             [Symbol(bytes)] if bytes == "BytesInWord" => Ok(Self::BytesInWord),
-            [Symbol(op), List(label), List(args), Symbol(ret)] if op == "call" => {
+            [Symbol(op), List(label), List(args), Symbol(_ret)] if op == "call" => {
                 Ok(Self::Call(ExprCall {
-                    expected_rettype: Shape::parse(ret)?,
                     fname: Box::new(Self::parse(label)?),
                     args: Self::parse_slice(args)?,
                 }))
             }
             [Symbol(op), List(label), List(args), Int(_)] if op == "call" => {
                 Ok(Self::Call(ExprCall {
-                    expected_rettype: Shape::Simple,
                     fname: Box::new(Self::parse(label)?),
                     args: Self::parse_slice(args)?,
                 }))
@@ -263,14 +261,12 @@ impl Stmt {
             })),
             [Symbol(op), List(label), List(args), Symbol(ret)] if op == "call" => {
                 Ok(Self::Call(Call {
-                    rettype: ret.into(),
                     fname: Expr::parse(label)?,
                     args: Expr::parse_slice(args)?,
                 }))
             }
             [Symbol(op), List(label), List(args), Int(_ret)] if op == "call" => {
                 Ok(Self::Call(Call {
-                    rettype: "todo_call".into(),
                     fname: Expr::parse(label)?,
                     args: Expr::parse_slice(args)?,
                 }))

--- a/pancake2viper/src/pancake/statement.rs
+++ b/pancake2viper/src/pancake/statement.rs
@@ -116,7 +116,6 @@ pub struct While {
 
 #[derive(Debug, Clone)]
 pub struct Call {
-    pub rettype: String,
     pub fname: Expr,
     pub args: Vec<Expr>,
 }

--- a/pancake2viper/tests/issue_42.pnk
+++ b/pancake2viper/tests/issue_42.pnk
@@ -1,0 +1,9 @@
+fun plus_one(1 x) {
+    return x + 1;
+}
+
+fun main() {
+    var y = 42;
+    y = plus_one(y);
+    return 0;
+}


### PR DESCRIPTION
parser was expecting a shpae, when a string containing "no_handler" etc. is provided by the output of the cake compiler
fixes #42 