### PR TITLE
Implemented bounded arithmetic

### DIFF
--- a/pancake2viper/src/cli.rs
+++ b/pancake2viper/src/cli.rs
@@ -17,6 +17,18 @@ pub struct CliOptions {
     )]
     pub tac: bool,
 
+    #[arg(
+        long,
+        help = "Check that variables don't under- or overflow their size"
+    )]
+    pub check_overflows: bool,
+
+    #[arg(
+        long,
+        help = "Model arithmetic operations as bounded (implicit under- or overflows)"
+    )]
+    pub bounded_arithmetic: bool,
+
     #[arg(long, help = "Removes assertions for alignment of memory operations")]
     pub disable_assert_alignment: bool,
 
@@ -67,6 +79,8 @@ impl From<CliOptions> for EncodeOptions {
             assert_aligned_accesses: !value.disable_assert_alignment,
             word_size: value.word_size.into(),
             heap_size: value.heap_size,
+            check_overflows: value.check_overflows,
+            bounded_arithmetic: value.bounded_arithmetic,
         }
     }
 }

--- a/pancake2viper/src/ir/display.rs
+++ b/pancake2viper/src/ir/display.rs
@@ -1,0 +1,227 @@
+use std::fmt::{Display, Formatter, Result};
+
+use crate::utils::Shape;
+
+use super::{
+    AnnotationType, BinOpType, Decl, Expr, Permission, Quantifier, ShiftType, SliceType, Stmt,
+    Type, UnOpType,
+};
+
+impl Display for Stmt {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        match self {
+            Self::Skip => write!(f, "skip;"),
+            Self::Break => write!(f, "break;"),
+            Self::Continue => write!(f, "continue;"),
+            Self::Return => write!(f, "return;"),
+            Self::Definition(def) => write!(f, "var {} = {};", def.lhs, def.rhs),
+            Self::Assign(ass) => write!(f, "{} = {};", ass.lhs, ass.rhs),
+            Self::If(i) => write!(f, "if ({}) ...", i.cond),
+            Self::While(w) => write!(f, "while ({}) ...", w.cond),
+            Self::Seq(_) => write!(f, "Sequence"),
+            Self::Annotation(annot) => write!(f, "/*@ {} {} @*/", annot.typ, annot.expr),
+            Self::Store(store) => write!(f, "st {}, {};", store.address, store.value),
+            Self::StoreBits(store) => write!(
+                f,
+                "st{} {}, {};",
+                store.size.bits(),
+                store.address,
+                store.value
+            ),
+            Self::SharedStore(store) => write!(f, "@st {}, {};", store.address, store.value),
+            Self::SharedStoreBits(store) => write!(
+                f,
+                "@st{} {}, {};",
+                store.size.bits(),
+                store.address,
+                store.value
+            ),
+            Self::SharedLoad(load) => write!(f, "@ldw {}, {};", load.dst, load.address),
+            Self::SharedLoadBits(load) => {
+                write!(f, "@ld{} {}, {};", load.size.bits(), load.dst, load.address)
+            }
+            Self::ExtCall(call) => write!(f, "@{}({})", call.fname, exprs_to_string(&call.args)),
+            Self::Call(call) => write!(f, "{}", call.call),
+        }
+    }
+}
+
+impl Display for Expr {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        match self {
+            Self::Const(c) => write!(f, "{}", c),
+            Self::Var(v) => write!(f, "{}", v),
+            Self::Label(l) => write!(f, "{}", l),
+            Self::BaseAddr => write!(f, "@base"),
+            Self::BytesInWord => write!(f, "@biw"),
+            Self::UnOp(op) => write!(f, "{}{}", op.optype, op.right),
+            Self::BinOp(op) => write!(f, "(){} {} {})", op.left, op.optype, op.right),
+            Self::Shift(shift) => {
+                write!(f, "(){} {} {})", shift.value, shift.shifttype, shift.amount)
+            }
+            Self::Load(load) => write!(f, "(lds {} {})", load.shape, load.address),
+            Self::LoadBits(load) => write!(f, "(ld{} {})", load.size.bits(), load.address),
+            Self::Struct(s) => write!(f, "<{}>", exprs_to_string(&s.elements)),
+            Self::Field(field) => write!(f, "{}.{}", field.obj, field.field_idx),
+            Self::Old(old) => write!(f, "old({})", old.expr),
+            Self::MethodCall(call) => write!(f, "{}({})", call.fname, exprs_to_string(&call.args)),
+            Self::FunctionCall(call) => {
+                write!(f, "{}({})", call.fname, exprs_to_string(&call.args))
+            }
+            Self::Quantified(quant) => write!(
+                f,
+                "(){} {} :: {})",
+                quant.quantifier,
+                decls_to_string(&quant.decls),
+                quant.body,
+            ),
+            Self::ArrayAccess(acc) => write!(f, "{}[{}]", acc.obj, acc.idx),
+            Self::AccessPredicate(acc) => write!(f, "acc({}, {})", acc.field, acc.perm),
+            Self::AccessSlice(acc) => write!(
+                f,
+                "acc({}[{}{}{}], {})",
+                acc.field, acc.lower, acc.typ, acc.upper, acc.perm
+            ),
+            Self::FieldAccessChain(acc) => {
+                write! {f, "{}.{}", acc.obj, acc.idxs.iter().map(usize::to_string).collect::<Vec<_>>().join(".")}
+            }
+            Self::UnfoldingIn(fold) => write!(f, "(unfolding {} in {})", fold.pred, fold.expr),
+            Self::Ternary(t) => write!(f, "(({}) ? {} : {})", t.cond, t.left, t.right),
+        }
+    }
+}
+
+impl Display for Permission {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        match self {
+            Self::Read => write!(f, "read"),
+            Self::Write => write!(f, "write"),
+            Self::Wildcard => write!(f, "wildcard"),
+            Self::Fractional(e, d) => write!(f, "{}/{}", e, d),
+        }
+    }
+}
+
+impl Display for ShiftType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        match self {
+            Self::Lsl => write!(f, "<<"),
+            Self::Asr => write!(f, ">>"),
+            Self::Lsr => write!(f, ">>>"),
+        }
+    }
+}
+
+impl Display for UnOpType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        match self {
+            Self::Neg => write!(f, "!"),
+            Self::Minus => write!(f, "-"),
+        }
+    }
+}
+
+impl Display for BinOpType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::Gt => ">",
+                Self::Lt => "<",
+                Self::Add => "+",
+                Self::Sub => "-",
+                Self::Mul => "*",
+                Self::Div => "/",
+                Self::Imp => "==>",
+                Self::Iff => "<==>",
+                Self::Gte => ">=",
+                Self::Lte => "<=",
+                Self::BitOr => "|",
+                Self::BitAnd => "&",
+                Self::BitXor => "^",
+                Self::Modulo => "%",
+                Self::BoolOr => "||",
+                Self::BoolAnd => "&&",
+                Self::ViperEqual => "===",
+                Self::ViperNotEqual => "!==",
+                Self::PancakeEqual => "==",
+                Self::PancakeNotEqual => "!=",
+            }
+        )
+    }
+}
+
+impl Display for SliceType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        match self {
+            Self::Inclusive => write!(f, "..="),
+            Self::Exclusive => write!(f, ".."),
+        }
+    }
+}
+
+impl Display for AnnotationType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::Inhale => "inhale",
+                Self::Exhale => "exhale",
+                Self::Assertion => "assert",
+                Self::Assumption => "assume",
+                Self::Invariant => "invariant",
+                Self::Refutation => "refute",
+                Self::Precondition => "requires",
+                Self::Postcondition => "ensures",
+                Self::Fold => "fold",
+                Self::Unfold => "unfold",
+            }
+        )
+    }
+}
+
+impl Display for Type {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        match self {
+            Self::Int => write!(f, "Int"),
+            Self::Bool => write!(f, "Bool"),
+            Self::Struct(s) => write!(f, "{}", Shape::Nested(s.to_vec())),
+            Self::Wildcard => write!(f, "*"),
+            Self::Void => write!(f, "Void"),
+            Self::Array => write!(f, "IArray"),
+        }
+    }
+}
+
+impl Display for Decl {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        write!(f, "{}: {}", self.name, self.typ)
+    }
+}
+
+impl Display for Quantifier {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        match self {
+            Self::Forall => write!(f, "forall"),
+            Self::Exists => write!(f, "exists"),
+        }
+    }
+}
+
+fn exprs_to_string(exprs: &[Expr]) -> String {
+    exprs
+        .iter()
+        .map(Expr::to_string)
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn decls_to_string(decls: &[Decl]) -> String {
+    decls
+        .iter()
+        .map(Decl::to_string)
+        .collect::<Vec<_>>()
+        .join(", ")
+}

--- a/pancake2viper/src/ir/display.rs
+++ b/pancake2viper/src/ir/display.rs
@@ -55,7 +55,7 @@ impl Display for Expr {
             Self::BaseAddr => write!(f, "@base"),
             Self::BytesInWord => write!(f, "@biw"),
             Self::UnOp(op) => write!(f, "{}{}", op.optype, op.right),
-            Self::BinOp(op) => write!(f, "(){} {} {})", op.left, op.optype, op.right),
+            Self::BinOp(op) => write!(f, "({} {} {})", op.left, op.optype, op.right),
             Self::Shift(shift) => {
                 write!(f, "(){} {} {})", shift.value, shift.shifttype, shift.amount)
             }

--- a/pancake2viper/src/ir/mod.rs
+++ b/pancake2viper/src/ir/mod.rs
@@ -1,3 +1,4 @@
+mod display;
 mod expression;
 pub mod mangle;
 mod statement;

--- a/pancake2viper/src/ir/utils.rs
+++ b/pancake2viper/src/ir/utils.rs
@@ -1,9 +1,9 @@
-use crate::utils::Shape;
+use crate::utils::{Shape, ToType};
 
 use super::{
     expression::{Expr, Struct},
     statement::MemOpBytes,
-    Arg, Decl, Type,
+    Arg, BinOpType, Decl, Type,
 };
 
 impl Struct {
@@ -65,5 +65,16 @@ impl Type {
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.len() == 0
+    }
+}
+
+impl ToType for BinOpType {
+    fn to_type(&self) -> super::Type {
+        use BinOpType::*;
+        match self {
+            Gt | Gte | Lt | Lte | BoolAnd | BoolOr | ViperEqual | ViperNotEqual => Type::Bool,
+            PancakeEqual | PancakeNotEqual => Type::Bool, // FIXME: enforce `===` vs `==`
+            _ => Type::Int,
+        }
     }
 }

--- a/pancake2viper/src/ir_to_viper/expression.rs
+++ b/pancake2viper/src/ir_to_viper/expression.rs
@@ -104,7 +104,7 @@ impl<'a> TryToViper<'a> for ir::BinOp {
             self.left.to_viper(ctx)?,
             self.right.to_viper(ctx)?,
         );
-        Ok(if ctx.options.expr_unrolling {
+        Ok(if ctx.options.expr_unrolling && !is_annot {
             let typ = if is_annot {
                 self.optype.to_type()
             } else {

--- a/pancake2viper/src/ir_to_viper/expression.rs
+++ b/pancake2viper/src/ir_to_viper/expression.rs
@@ -134,7 +134,7 @@ impl<'a> TryToViper<'a> for ir::BinOp {
             }
 
             if ctx.options.check_overflows {
-                let assertion = ast.assert(ctx.word_bound(fresh_var.1), ast.no_position());
+                let assertion = ast.assert(ctx.utils.bounded_f(fresh_var.1), ast.no_position());
                 ctx.stack.push(assertion);
                 if let TranslationMode::WhileCond = ctx.get_mode() {
                     ctx.while_stack.push(assertion);

--- a/pancake2viper/src/ir_to_viper/expression.rs
+++ b/pancake2viper/src/ir_to_viper/expression.rs
@@ -281,6 +281,7 @@ impl<'a> TryToViper<'a> for ir::FunctionCall {
                 args.insert(0, ctx.heap_var().1);
                 ast.predicate_access_predicate(ast.predicate_access(&args, pred), ast.full_perm())
             }
+            "f_bounded" => ctx.utils.bounded_f(args[0]),
             fname => {
                 args.insert(0, ctx.heap_var().1);
                 let ret_type = ctx

--- a/pancake2viper/src/ir_to_viper/statement.rs
+++ b/pancake2viper/src/ir_to_viper/statement.rs
@@ -75,9 +75,11 @@ impl<'a> TryToViper<'a> for ir::While {
 
         let decls = ctx.pop_decls();
 
-        let mut body_seq = ctx.stack.clone();
+        let mut body_seq = ctx.while_stack.clone();
         body_seq.push(body);
         body_seq.push(ast.label(&ctx.current_continue_label(), &[]));
+        body_seq.extend(ctx.stack.clone());
+
         let body = ast.seqn(&body_seq, &[]);
 
         ctx.stack.push(ast.while_stmt(
@@ -86,6 +88,7 @@ impl<'a> TryToViper<'a> for ir::While {
             body,
         ));
         ctx.stack.push(ast.label(&ctx.current_break_label(), &[]));
+        ctx.stack.append(&mut ctx.while_stack);
         let seq = ast.seqn(&ctx.stack, &decls);
         ctx.stack.clear();
         Ok(seq)

--- a/pancake2viper/src/ir_to_viper/statement.rs
+++ b/pancake2viper/src/ir_to_viper/statement.rs
@@ -11,6 +11,7 @@ impl<'a> TryToViper<'a> for ir::Stmt {
     fn to_viper(self, ctx: &mut ViperEncodeCtx<'a>) -> Result<Self::Output, ToViperError> {
         let ast = ctx.ast;
         use ir::Stmt::*;
+        ctx.stack.push(ast.comment(&format!("Stmt: {}", self)));
         let stmt = match self {
             Skip => ast.comment("skip"),
             Break => ast.goto(&ctx.outer_break_label()),

--- a/pancake2viper/src/ir_to_viper/toplevel.rs
+++ b/pancake2viper/src/ir_to_viper/toplevel.rs
@@ -27,11 +27,13 @@ impl<'a> TryToViper<'a> for FnDec {
         let mut pres = self
             .args
             .iter()
-            .filter_map(|a| a.permission(ctx))
+            .filter_map(|a| a.precondition(ctx))
             .collect::<Vec<_>>();
 
-        // add postcondition if returning struct
-        let mut posts = self.permission(ctx);
+        // Add postcondition:
+        // - length if returning struct
+        // - bound if returning word
+        let mut posts = self.postcondition(ctx);
 
         let mut args_local_decls = self.args.to_viper(ctx);
 
@@ -205,7 +207,7 @@ impl<'a> ProgramToViper<'a> for Program {
                 f.to_viper(&mut ctx)
             })
             .collect::<Result<Vec<_>, _>>()?;
-        let (domains, fields, mut methods, fs) = create_viper_prelude(ast);
+        let (domains, fields, mut methods, fs) = create_viper_prelude(ast, options);
         methods.extend(abstract_methods.iter());
         methods.extend(program_methods.iter());
         functions.extend(fs.iter());

--- a/pancake2viper/src/utils/contexts.rs
+++ b/pancake2viper/src/utils/contexts.rs
@@ -3,7 +3,7 @@ use std::collections::{HashMap, HashSet};
 use viper::{AstFactory, Declaration, LocalVarDecl};
 
 use crate::{
-    ir::{self, types::Type, AnnotationType},
+    ir::{types::Type, AnnotationType},
     viper_prelude::IArrayHelper,
 };
 

--- a/pancake2viper/src/utils/contexts.rs
+++ b/pancake2viper/src/utils/contexts.rs
@@ -111,7 +111,7 @@ pub struct EncodeOptions {
 impl Default for EncodeOptions {
     fn default() -> Self {
         Self {
-            expr_unrolling: false,
+            expr_unrolling: true,
             assert_aligned_accesses: true,
             word_size: 64,
             heap_size: 16 * 1024,

--- a/pancake2viper/src/utils/contexts.rs
+++ b/pancake2viper/src/utils/contexts.rs
@@ -4,7 +4,7 @@ use viper::{AstFactory, Declaration, LocalVarDecl};
 
 use crate::{
     ir::{types::Type, AnnotationType},
-    viper_prelude::IArrayHelper,
+    viper_prelude::{utils::Utils, IArrayHelper},
 };
 
 use super::{mangler::Mangler, TranslationError, ViperUtils, RESERVED};
@@ -93,6 +93,7 @@ pub struct ViperEncodeCtx<'a> {
     while_counter: u64,
     types: TypeContext,
     pub iarray: IArrayHelper<'a>,
+    pub utils: Utils<'a>,
     pub options: EncodeOptions,
 
     pub pres: Vec<viper::Expr<'a>>,
@@ -120,7 +121,7 @@ impl Default for EncodeOptions {
             word_size: 64,
             heap_size: 16 * 1024,
             check_overflows: true,
-            bounded_arithmetic: true,
+            bounded_arithmetic: false,
         }
     }
 }
@@ -141,6 +142,7 @@ impl<'a> ViperEncodeCtx<'a> {
             types,
             while_counter: 0,
             iarray: IArrayHelper::new(ast),
+            utils: Utils::new(ast),
             options,
             pres: vec![],
             posts: vec![],
@@ -160,6 +162,7 @@ impl<'a> ViperEncodeCtx<'a> {
             types: self.types.child(),
             while_counter: self.while_counter,
             iarray: self.iarray,
+            utils: self.utils,
             options: self.options,
             pres: vec![],
             posts: vec![],
@@ -261,12 +264,5 @@ impl<'a> ViperEncodeCtx<'a> {
             ast.int_lit(4),
             ast.int_lit(2i64.pow(self.options.word_size as u32 - 2)),
         )
-    }
-
-    pub fn word_bound(&self, expr: viper::Expr<'a>) -> viper::Expr<'a> {
-        let ast = self.ast;
-        let lower_bound = ast.le_cmp(ast.zero(), expr);
-        let upper_bound = ast.lt_cmp(expr, self.word_values());
-        ast.and(lower_bound, upper_bound)
     }
 }

--- a/pancake2viper/src/utils/contexts.rs
+++ b/pancake2viper/src/utils/contexts.rs
@@ -3,7 +3,7 @@ use std::collections::{HashMap, HashSet};
 use viper::{AstFactory, Declaration, LocalVarDecl};
 
 use crate::{
-    ir::{types::Type, AnnotationType},
+    ir::{self, types::Type, AnnotationType},
     viper_prelude::IArrayHelper,
 };
 
@@ -15,12 +15,13 @@ pub enum TranslationMode {
     Normal,
     PrePost,
     Assertion,
+    WhileCond,
 }
 
 impl TranslationMode {
     pub fn is_annot(&self) -> bool {
         match self {
-            Self::Normal => false,
+            Self::Normal | Self::WhileCond => false,
             Self::Assertion | Self::PrePost => true,
         }
     }
@@ -87,6 +88,7 @@ pub struct ViperEncodeCtx<'a> {
     mode: TranslationMode,
     pub ast: AstFactory<'a>,
     pub stack: Vec<viper::Stmt<'a>>,
+    pub while_stack: Vec<viper::Stmt<'a>>,
     pub declarations: Vec<viper::LocalVarDecl<'a>>,
     while_counter: u64,
     types: TypeContext,
@@ -134,6 +136,7 @@ impl<'a> ViperEncodeCtx<'a> {
             mode: TranslationMode::Normal,
             ast,
             stack: vec![],
+            while_stack: vec![],
             declarations: vec![],
             types,
             while_counter: 0,
@@ -152,6 +155,7 @@ impl<'a> ViperEncodeCtx<'a> {
             mode: self.mode,
             ast: self.ast,
             stack: vec![],
+            while_stack: vec![],
             declarations: vec![],
             types: self.types.child(),
             while_counter: self.while_counter,

--- a/pancake2viper/src/utils/mangler.rs
+++ b/pancake2viper/src/utils/mangler.rs
@@ -53,7 +53,7 @@ impl Mangler {
         if RESERVED.contains_key(name.as_str()) {
             return Err(MangleError::ReservedKeyword(name));
         }
-        let mangled = format!("{}_{}_{}", self.get_fname(), &name, get_inc_counter());
+        let mangled = format!("{}_{}", &name, get_inc_counter());
         let map = match (&typ, self.mode) {
             (VariableType::Variable, TranslationMode::Normal) => &mut self.var_map,
             (VariableType::Variable, _) => &mut self.annot_map,

--- a/pancake2viper/src/utils/mangler.rs
+++ b/pancake2viper/src/utils/mangler.rs
@@ -95,7 +95,7 @@ impl Mangler {
         let maybe_annot = self.annot_map.get(var);
         let maybe_var = self.var_map.get(var);
         match self.mode {
-            TranslationMode::Normal => maybe_var.or(maybe_arg),
+            TranslationMode::Normal | TranslationMode::WhileCond => maybe_var.or(maybe_arg),
             TranslationMode::Assertion => maybe_annot.or(maybe_var),
             TranslationMode::PrePost => maybe_annot.or(maybe_arg),
         }

--- a/pancake2viper/src/utils/mod.rs
+++ b/pancake2viper/src/utils/mod.rs
@@ -24,6 +24,7 @@ lazy_static::lazy_static! {
         ("wildcard", Type::Void),
         ("acc", Type::Bool),
         ("alen", Type::Int),
-        ("old", Type::Wildcard)
+        ("old", Type::Wildcard),
+        ("bounded", Type::Bool),
     ]);
 }

--- a/pancake2viper/src/utils/shape.rs
+++ b/pancake2viper/src/utils/shape.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use super::{errors::ShapeError, traits::ToViperType, ViperEncodeCtx};
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
@@ -43,6 +45,25 @@ impl<'a> ToViperType<'a> for Shape {
         match self {
             Self::Simple => ctx.ast.int_type(),
             Self::Nested(_) => ctx.iarray.get_type(),
+        }
+    }
+}
+
+impl Display for Shape {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Simple => write!(f, "1"),
+            Self::Nested(inner) => {
+                write!(
+                    f,
+                    "{{{}}}",
+                    inner
+                        .iter()
+                        .map(Self::to_string)
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                )
+            }
         }
     }
 }

--- a/pancake2viper/src/viper_prelude/mod.rs
+++ b/pancake2viper/src/viper_prelude/mod.rs
@@ -2,47 +2,29 @@ pub mod bitvector;
 pub mod ext_calls;
 pub mod iarray;
 pub mod shared_mem;
+pub mod utils;
 
 use bitvector::create_bv_domain;
 pub use iarray::IArrayHelper;
 use shared_mem::create_shared_mem_methods;
+use utils::{bound_function, pow_function};
 use viper::{AstFactory, Domain, Field, Function, Method};
 
-use crate::utils::ViperUtils;
-
-fn pow_function(ast: AstFactory) -> Function {
-    let (e_decl, e) = ast.new_var("e", ast.int_type());
-    let body = ast.cond_exp(
-        ast.eq_cmp(e, ast.zero()),
-        ast.one(),
-        ast.mul(
-            ast.two(),
-            ast.func_app(
-                "pow",
-                &[ast.sub(e, ast.one())],
-                ast.int_type(),
-                ast.no_position(),
-            ),
-        ),
-    );
-    ast.function(
-        "pow",
-        &[e_decl],
-        ast.int_type(),
-        &[ast.ge_cmp(e, ast.zero())],
-        &[],
-        ast.no_position(),
-        Some(body),
-    )
-}
+use crate::utils::EncodeOptions;
 
 pub fn create_viper_prelude(
     ast: AstFactory,
+    options: EncodeOptions,
 ) -> (Vec<Domain>, Vec<Field>, Vec<Method>, Vec<Function>) {
     let iarray = IArrayHelper::new(ast);
     let domains = vec![iarray.domain, create_bv_domain(ast)];
     let fields = vec![iarray.field()];
     let mut methods = iarray.slice_defs();
     methods.extend(create_shared_mem_methods(ast));
-    (domains, fields, methods, vec![pow_function(ast)])
+    (
+        domains,
+        fields,
+        methods,
+        vec![pow_function(ast), bound_function(ast, options.word_size)],
+    )
 }

--- a/pancake2viper/src/viper_prelude/utils.rs
+++ b/pancake2viper/src/viper_prelude/utils.rs
@@ -1,0 +1,69 @@
+use viper::{AstFactory, Expr, Function};
+
+use crate::utils::ViperUtils;
+
+pub fn bound_function(ast: AstFactory, word_size: u64) -> Function {
+    let x = ast.new_var("x", ast.int_type());
+    let body = ast.and(
+        ast.le_cmp(ast.zero(), x.1),
+        ast.lt_cmp(
+            x.1,
+            ast.mul(ast.int_lit(4), ast.int_lit(2i64.pow(word_size as u32 - 2))),
+        ),
+    );
+    ast.function(
+        "bounded",
+        &[x.0],
+        ast.bool_type(),
+        &[],
+        &[],
+        ast.no_position(),
+        Some(body),
+    )
+}
+
+pub fn pow_function(ast: AstFactory) -> Function {
+    let (e_decl, e) = ast.new_var("e", ast.int_type());
+    let body = ast.cond_exp(
+        ast.eq_cmp(e, ast.zero()),
+        ast.one(),
+        ast.mul(
+            ast.two(),
+            ast.func_app(
+                "pow",
+                &[ast.sub(e, ast.one())],
+                ast.int_type(),
+                ast.no_position(),
+            ),
+        ),
+    );
+    ast.function(
+        "pow",
+        &[e_decl],
+        ast.int_type(),
+        &[ast.ge_cmp(e, ast.zero())],
+        &[],
+        ast.no_position(),
+        Some(body),
+    )
+}
+
+#[derive(Clone, Copy)]
+pub struct Utils<'a> {
+    ast: AstFactory<'a>,
+}
+
+impl<'a> Utils<'a> {
+    pub fn new(ast: AstFactory<'a>) -> Self {
+        Self { ast }
+    }
+
+    pub fn bounded_f(&self, var: Expr) -> Expr<'a> {
+        self.ast.func_app(
+            "bounded",
+            &[var],
+            self.ast.bool_type(),
+            self.ast.no_position(),
+        )
+    }
+}

--- a/pancake2viper/tests/arg_copy_semantics.pnk
+++ b/pancake2viper/tests/arg_copy_semantics.pnk
@@ -8,6 +8,7 @@ fun main(2 x) {
 
 fun do_stuff(2 x) {
     /*@ requires acc(x[0..2]) @*/
+    /*@ ensures acc(x[0..2]) @*/
     x = < 0, 0 >;
     return 0;
 }

--- a/pancake2viper/tests/arg_copy_semantics_struct.pnk
+++ b/pancake2viper/tests/arg_copy_semantics_struct.pnk
@@ -1,0 +1,19 @@
+/* @ predicate my_array(array: IArray) {
+  alen(array) == 2 && acc(array[0..2])
+}
+@*/
+
+fun main() {
+    var test = <1,2>;
+    /*@ fold my_array(test) @*/
+    var 1 res = tuple_equal(test);
+    return 0;
+}
+
+fun tuple_equal({1,1} buffer) {
+    /*@ requires my_array(buffer) @*/
+    /*@ ensures (retval == 1) || (retval == 0) @*/
+    /*@ unfold my_array(buffer) @*/
+    var ret = (buffer.0 == buffer.1);
+    return ret;
+}

--- a/pancake2viper/tests/array_sum.pnk
+++ b/pancake2viper/tests/array_sum.pnk
@@ -8,12 +8,14 @@
 
 fun array_sum(1 arr, 1 len) {
     /*@ requires arr >= 0 && len >= 0 */
+    /*@ requires len < 1000 @*/
     /*@ requires arr % 8 == 0 @*/ // word-aligned
     /*@ requires arr / 8 + len <= alen(heap) @*/ // the array fits into the heap
 
     // Borrows whole array
     /*@ requires forall i: Int :: arr / 8 <= i && i < arr / 8 + len ==> acc(heap[i], read) @*/
     /*@ ensures forall i: Int :: arr / 8 <= i && i < arr / 8 + len ==> acc(heap[i], read) @*/
+    /*@ requires forall i: Int :: arr / 8 <= i && i < arr / 8 + len ==> 0 <= heap[i] && heap[i] < 256 @*/
 
     /*@ ensures sum(arr / 8, len) == retval */
 
@@ -23,8 +25,12 @@ fun array_sum(1 arr, 1 len) {
         /*@ invariant arr % 8 == 0 @*/
         /*@ invariant 0 <= i && i <= len @*/
         /*@ invariant forall i: Int :: arr / 8 <= i && i < arr / 8 + len ==> acc(heap[i], read) @*/
+        /*@ invariant forall i: Int :: arr / 8 <= i && i < arr / 8 + len ==> (0 <= heap[i] && heap[i] < 256) @*/
         /*@ invariant accu == sum(arr / 8, i) @*/
+        /*@ invariant accu >= 0 @*/
+        /*@ invariant sum(arr / 8, i) <= 255 * i @*/
         var tmp = lds 1 arr + i * @biw;
+        /*@ assert 0 <= tmp && tmp < 256 @*/
         accu = accu + tmp;
         i = i + 1;
     }

--- a/pancake2viper/tests/auto_arg.pnk
+++ b/pancake2viper/tests/auto_arg.pnk
@@ -1,4 +1,5 @@
 fun main(2 x) {
     /*@ requires acc(x[0..2], read) @*/
+    /*@ requires 0 <= x.0 && x.0 <= 10000 @*/
     return x.0;
 }

--- a/pancake2viper/tests/auto_return_struct.pnk
+++ b/pancake2viper/tests/auto_return_struct.pnk
@@ -1,5 +1,4 @@
 fun dostuff() {
-    /*@ ensures acc(retval[0..2], read) @*/
     /*@ ensures retval.0 == 1 @*/
     /*@ ensures retval.1 == 2 @*/
     return < 1, 2 >;

--- a/pancake2viper/tests/calls.pnk
+++ b/pancake2viper/tests/calls.pnk
@@ -6,6 +6,7 @@ fun main() {
 }
 
 fun foo(1 x) {
+    /*@ ensures 0 <= retval && retval < 256 @*/
     return x;
 }
 

--- a/pancake2viper/tests/calls.pnk
+++ b/pancake2viper/tests/calls.pnk
@@ -6,7 +6,7 @@ fun main() {
 }
 
 fun foo(1 x) {
-    /*@ ensures 0 <= retval && retval < 256 @*/
+    /*@ ensures x == retval @*/
     return x;
 }
 

--- a/pancake2viper/tests/fix_triggers.pnk
+++ b/pancake2viper/tests/fix_triggers.pnk
@@ -6,6 +6,7 @@ fun test() {
     while (true) {
         /*@ invariant acc(heap[@base]) @*/
         /*@ invariant acc(heap[@base + 1]) @*/
+        /*@ invariant 0 <= i && i <= 10 @*/
         x = lds {1, 1} @base;
         st @base, x;
         if (i == 10) {

--- a/pancake2viper/tests/function_result.pnk
+++ b/pancake2viper/tests/function_result.pnk
@@ -1,0 +1,7 @@
+/* @ function pnk_true(): Int
+    ensures result == 1
+@*/
+
+fun main() {
+    return 0;
+}

--- a/pancake2viper/tests/int_bounds.pnk
+++ b/pancake2viper/tests/int_bounds.pnk
@@ -1,0 +1,3 @@
+fun main(1 x) {
+    return x + 1;
+}

--- a/pancake2viper/tests/int_bounds.pnk
+++ b/pancake2viper/tests/int_bounds.pnk
@@ -1,3 +1,5 @@
 fun main(1 x) {
+    /*@ requires 0 <= x && x < 255 @*/
+    /*@ ensures 0 <= retval && retval < 256 @*/
     return x + 1;
 }

--- a/pancake2viper/tests/issue_42.pnk
+++ b/pancake2viper/tests/issue_42.pnk
@@ -1,4 +1,5 @@
 fun plus_one(1 x) {
+    /*@ requires x <= 10000 @*/
     return x + 1;
 }
 

--- a/pancake2viper/tests/lds.pnk
+++ b/pancake2viper/tests/lds.pnk
@@ -2,6 +2,8 @@ fun main() {
     /*@ requires acc(heap[0]) @*/
     /*@ requires acc(heap[1]) @*/
     /*@ requires acc(heap[2]) @*/
+    /*@ requires 0 <= heap[0] && heap[0] < 256 @*/
+    /*@ requires 0 <= heap[2] && heap[2] < 256 @*/
     /*@ requires alen(heap) >= 3 @*/
     var x = lds {1} @base;
     var y = lds 2 @base + 8;

--- a/pancake2viper/tests/nested_while2.pnk
+++ b/pancake2viper/tests/nested_while2.pnk
@@ -2,7 +2,10 @@ fun double_while() {
     var i = 0;
     var j = 0;
     while (i < 10) {
+        /*@ invariant 0 <= i @*/
+        /*@ invariant 0 <= j @*/
         while (j < 10) {
+        /*@ invariant 0 <= j @*/
             j = j + 1;
             if (j == 5) {
                 break;

--- a/pancake2viper/tests/return_struct.pnk
+++ b/pancake2viper/tests/return_struct.pnk
@@ -1,0 +1,8 @@
+fun foo() {
+    return < 0, 1>;
+}
+
+fun main() {
+    var 2 y = foo();
+    return y.0;
+}

--- a/pancake2viper/tests/unroll_while.pnk
+++ b/pancake2viper/tests/unroll_while.pnk
@@ -3,6 +3,7 @@ fun main() {
     var i = 0;
     while (i + 1 < 10) {
         /*@ invariant i + 1 <= 10 @*/
+        /*@ invariant 0 <= i @*/
         i = i + 1;
     }
     return i;

--- a/pancake2viper/tests/unroll_while.pnk
+++ b/pancake2viper/tests/unroll_while.pnk
@@ -1,0 +1,9 @@
+fun main() {
+    /*@ ensures retval == 9 @*/
+    var i = 0;
+    while (i + 1 < 10) {
+        /*@ invariant i + 1 <= 10 @*/
+        i = i + 1;
+    }
+    return i;
+}

--- a/pancake2viper/tests/while.pnk
+++ b/pancake2viper/tests/while.pnk
@@ -1,11 +1,11 @@
 fun sum(1 n) {
-    /*@ requires 0 <= n @*/
+    /*@ requires 0 <= n && n < 100000 @*/ // need upper bound for overflow of word
     /*@ ensures retval == n * (n + 1) / 2 @*/
     var i = 0;
     var accu = 0;
     while (i < n) {
         /*@ invariant 0 <= i && i <= n @*/
-        /*@ invariant accu == (i - 1) * i / 2 @*/
+        /*@ invariant accu == (((i - 1) * i) / 2) @*/
         accu = accu + i;
         i = i + 1;
     }


### PR DESCRIPTION
all integers are treated as `usize` (unsigned word size) integers in Viper
overflows are checked with assertions after unrolling of arithmetic expressions into Three-Access Code.
- fixed access permissions and bounds for returned values
- fixed all the tests s.t. they work with bounded arithmetic