### PR TITLE
Add seq length `| .. |` support in annotation

### DIFF
--- a/pancake2viper/src/annotation/annot.pest
+++ b/pancake2viper/src/annotation/annot.pest
@@ -1,4 +1,4 @@
-// The Pancake compiler converts newlines and tabs into multiple characters '\' 'n' 
+// The Pancake compiler converts newlines and tabs into multiple characters '\' 'n'
 // instead of using the newline character '\n'.
 WHITESPACE = _{ " " | "\\t" | "\t" | "\\r" | "\\n" | NEWLINE }
 
@@ -55,9 +55,9 @@ expr = !{ prefix? ~ primary ~ postfix* ~ (infix ~ prefix? ~ primary ~ postfix*)*
     prefix = _{ neg | minus }
         neg = { "!" }
         minus = { "-" }
-    
+
     postfix = _{ field_acc | viper_field_acc | arr_acc | ternary | shift }
-		viper_field_acc = @{ "." ~ ident }	
+		viper_field_acc = @{ "." ~ ident }
         field_acc = @{ "." ~ field_idx }
             field_idx = !{ integer }
         arr_acc = @{ "[" ~ expr ~ "]" }
@@ -68,7 +68,7 @@ expr = !{ prefix? ~ primary ~ postfix* ~ (infix ~ prefix? ~ primary ~ postfix*)*
                 ashr = { ">>" }
                 lshl = { "<<" }
 
-    primary = _{ "(" ~ expr ~ ")" | unfolding | int_lit | quantified | acc_pred | acc_slice | old | f_call | struc | field_acc | bool_lit | ident | biw | base }
+    primary = _{ "(" ~ expr ~ ")" | unfolding | int_lit | quantified | acc_pred | acc_slice | old | f_call | struc | field_acc | bool_lit | ident | biw | base | seq_length }
 
 		struc = { "<" ~ expr ~ ("," ~ expr)* ~ ">" }
         quantified = { (forall | exists) ~ decl ~ ("," ~ decl)* ~ "::" ~ triggers ~ expr }
@@ -87,6 +87,7 @@ expr = !{ prefix? ~ primary ~ postfix* ~ (infix ~ prefix? ~ primary ~ postfix*)*
                 perm_var = { ident }
 
         old = {"old(" ~ expr ~ ")" }
+        seq_length = { "|" ~ expr ~ "|" }
         f_call = {ident ~ "(" ~ (expr ~ ("," ~ expr)* | "") ~ ")" }
         unfolding = { "unfolding" ~ f_call ~ "in" ~ expr }
         biw = { "@biw" }

--- a/pancake2viper/src/annotation/parser.rs
+++ b/pancake2viper/src/annotation/parser.rs
@@ -281,6 +281,10 @@ fn parse_expr(pairs: Pairs<Rule>) -> Expr {
             Rule::biw => Expr::BytesInWord,
             Rule::true_lit => Expr::BoolLit(true),
             Rule::false_lit => Expr::BoolLit(false),
+            Rule::seq_length => Expr::SeqLength(
+                SeqLength {
+                    expr: Box::new(parse_expr(primary.into_inner())),
+            }),
             _ => unreachable!(),
         })
         .map_prefix(|op, rhs| {

--- a/pancake2viper/src/ir/const_eval.rs
+++ b/pancake2viper/src/ir/const_eval.rs
@@ -83,6 +83,9 @@ impl ConstEvalExpr for Expr {
                 obj: Box::new(f.obj.const_eval(options)),
                 field: f.field,
             }),
+            SeqLength(s) => SeqLength(ir::SeqLength {
+                expr: Box::new(s.expr.const_eval(options)),
+            }),
         }
     }
 }

--- a/pancake2viper/src/ir/display.rs
+++ b/pancake2viper/src/ir/display.rs
@@ -86,6 +86,7 @@ impl Display for Expr {
             Self::UnfoldingIn(fold) => write!(f, "(unfolding {} in {})", fold.pred, fold.expr),
             Self::Ternary(t) => write!(f, "(({}) ? {} : {})", t.cond, t.left, t.right),
             Self::ViperFieldAccess(acc) => write!(f, "{}.{}", acc.obj, acc.field),
+            Self::SeqLength(seq) => write!(f, "|{}|", seq.expr),
         }
     }
 }

--- a/pancake2viper/src/ir/expression.rs
+++ b/pancake2viper/src/ir/expression.rs
@@ -29,6 +29,7 @@ pub enum Expr {
     AccessSlice(AccessSlice),
     Old(Old),
     ViperFieldAccess(ViperFieldAccess),
+    SeqLength(SeqLength),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -211,4 +212,9 @@ pub struct Old {
 pub struct ViperFieldAccess {
     pub obj: Box<Expr>,
     pub field: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct SeqLength {
+    pub expr: Box<Expr>,
 }

--- a/pancake2viper/src/ir/mangle.rs
+++ b/pancake2viper/src/ir/mangle.rs
@@ -77,6 +77,7 @@ impl Mangleable for ir::Expr {
             }
             Old(old) => old.expr.mangle(mangler)?,
             ViperFieldAccess(field) => field.obj.mangle(mangler)?,
+            SeqLength(seq) => seq.expr.mangle(mangler)?,
         }
         Ok(())
     }

--- a/pancake2viper/src/ir/types.rs
+++ b/pancake2viper/src/ir/types.rs
@@ -51,6 +51,7 @@ impl ExprTypeResolution for ir::Expr {
                 Ok(Type::Bool)
             }
             Old(old) => old.expr.resolve_expr_type(is_annot, ctx),
+            SeqLength(_) => Ok(Type::Int),
             ViperFieldAccess(acc) => ctx.get_field_type(&acc.field),
         }
     }

--- a/pancake2viper/src/ir/utils.rs
+++ b/pancake2viper/src/ir/utils.rs
@@ -254,6 +254,7 @@ impl ExprSubstitution for Expr {
             Self::Load(load) => load.address.substitute(old, new),
             Self::LoadBits(load) => load.address.substitute(old, new),
             Self::Old(o) => o.expr.substitute(old, new),
+            Self::SeqLength(s) => s.expr.substitute(old, new),
             Self::Shift(shift) => shift.value.substitute(old, new),
             Self::Struct(s) => s.elements.substitute(old, new),
             Self::Ternary(tern) => {

--- a/pancake2viper/src/ir_to_viper/expression.rs
+++ b/pancake2viper/src/ir_to_viper/expression.rs
@@ -442,6 +442,7 @@ impl<'a> TryToViper<'a> for ir::Expr {
                 BaseAddr => ast.zero(),
                 BytesInWord => ast.int_lit(ctx.options.word_size as i64 / 8),
                 Old(old) => ast.old(old.expr.to_viper(ctx)?),
+                SeqLength(s) => ast.seq_length(s.expr.to_viper(ctx)?),
                 _ => unreachable!(),
             }),
         }


### PR DESCRIPTION
To support annotations like `/@ capacity == |state.buffers| @/`.